### PR TITLE
update art version to 2.6.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@
           matrix:
             version:
               - '${{ inputs.version }}'
-              - '2.6.3' # need not be the most recent
+              - '2.6.4' # need not be the most recent
         steps:
         - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
     

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
   version:
     description: "Version of artifactory-repo-tool to install, e.g. v1.0.3."
-    default: "2.6.3"
+    default: "2.6.4"
   install-dir:
     description: "Where the tool will be installed; this directory will be added to GITHUB_PATH."
     default: "$HOME/bin"
@@ -24,7 +24,7 @@ inputs:
 outputs:
   version:
     description: "The version of artifactory-repo-tool that was installed as reported by the tool"
-    value: "2.6.3"
+    value: "2.6.4"
 
 runs:
   using: composite


### PR DESCRIPTION
Update `a.r.t.` to include new version of a.r.t. `v2.6.4` -- this includes a patch fix to remove `main` from the path string when we update the `deb.distribution` property. PR: https://github.com/hashicorp/artifactory-repo-tool/pull/68